### PR TITLE
Add support for Roblox App Beta for Windows

### DIFF
--- a/Hydroxide/rbx/object/task_scheduler.cppm
+++ b/Hydroxide/rbx/object/task_scheduler.cppm
@@ -65,20 +65,20 @@ export namespace rbx {
 			rbx::script_context* script_context;
 		};
 
-		using iterator = std::vector<std::shared_ptr<job>>::iterator;
+		using reverse_iterator = std::vector<std::shared_ptr<job>>::reverse_iterator;
 	private:
 		std::uint8_t _[300];
-		iterator _begin, _end;
+		reverse_iterator _end, _begin;
 	public:
 		task_scheduler() = delete;
 		task_scheduler(const task_scheduler&) = delete;
 		task_scheduler(const task_scheduler&&) = delete;
 
-		iterator begin() {
+		reverse_iterator begin() {
 			return _begin;
 		}
 
-		iterator end() {
+		reverse_iterator end() {
 			return _end;
 		}
 


### PR DESCRIPTION
Roblox App Beta for Windows has two Lua States which share the same task scheduler. The beta menu state loads before the game does and creates a WaitingScriptJob. The game state will then load and create another WaitingScriptJob. Since the task scheduler is shared, the iterator will find the beta menu's WaitingScriptJob before the game's. The fix is to reverse the order of iteration so that the game's job is found first. This fix will work on both the default client and beta client.

To enable the beta for testing simply add a string value in Computer\HKEY_CURRENT_USER\SOFTWARE\ROBLOX Corporation\Environments\roblox-player
Create a string value named "LaunchExp" with the value "InApp" then start the game

Info about the beta:
https://devforum.roblox.com/t/psa-the-roblox-app-beta-for-windows-is-now-underway/925069

It's very possible that this code doesn't work because I couldn't get the project to compile with vs 2019 and couldn't test it.